### PR TITLE
Add "vship" feature flag to enable vship-based TQ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["multimedia::video", "command-line-utilities"]
 [features]
 default = []
 static = ["av-decoders"]
+vship = []
 
 [dependencies]
 libc = "0.2.177"

--- a/build.rs
+++ b/build.rs
@@ -8,8 +8,6 @@ fn main() {
         println!("cargo:rustc-link-search=native={home}/.local/src/FFmpeg/install/lib");
         println!("cargo:rustc-link-search=native={home}/.local/src/dav1d/build/src");
         println!("cargo:rustc-link-search=native={home}/.local/src/zlib/install/lib");
-        println!("cargo:rustc-link-search=native={home}/.local/src/zimg/.libs");
-        println!("cargo:rustc-link-search=native={home}/.local/src/Vship");
 
         println!("cargo:rustc-link-lib=static=ffms2");
         println!("cargo:rustc-link-lib=static=swscale");
@@ -19,13 +17,19 @@ fn main() {
         println!("cargo:rustc-link-lib=static=dav1d");
         println!("cargo:rustc-link-lib=static=z");
 
-        println!("cargo:rustc-link-lib=static=zimg");
-        println!("cargo:rustc-link-lib=static=vship");
+        #[cfg(feature = "vship")]
+        {
+            println!("cargo:rustc-link-search=native={home}/.local/src/zimg/.libs");
+            println!("cargo:rustc-link-search=native={home}/.local/src/Vship");
 
-        println!("cargo:rustc-link-lib=static=cudart_static");
-        println!("cargo:rustc-link-lib=static=stdc++");
-        println!("cargo:rustc-link-search=native=/opt/cuda/lib64");
+            println!("cargo:rustc-link-lib=static=zimg");
+            println!("cargo:rustc-link-lib=static=vship");
 
-        println!("cargo:rustc-link-lib=dylib=cuda");
+            println!("cargo:rustc-link-lib=static=cudart_static");
+            println!("cargo:rustc-link-lib=static=stdc++");
+            println!("cargo:rustc-link-search=native=/opt/cuda/lib64");
+
+            println!("cargo:rustc-link-lib=dylib=cuda");
+        }
     }
 }

--- a/src/ffms.rs
+++ b/src/ffms.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 #[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct FFMS_ErrorInfo {
     error_type: i32,
     sub_type: i32,
@@ -11,6 +12,7 @@ pub struct FFMS_ErrorInfo {
 }
 
 #[repr(C)]
+#[allow(non_camel_case_types)]
 struct FFMS_VideoProperties {
     fps_denominator: i32,
     fps_numerator: i32,
@@ -47,6 +49,7 @@ struct FFMS_VideoProperties {
 }
 
 #[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct FFMS_Frame {
     pub data: [*const u8; 4],
     pub linesize: [i32; 4],
@@ -625,6 +628,7 @@ pub fn extr_10bit(
     }
 }
 
+#[cfg(feature = "vship")]
 pub fn get_frame(
     vid_src: *mut libc::c_void,
     frame_idx: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,13 +6,17 @@ use std::path::{Path, PathBuf};
 
 mod chunk;
 mod ffms;
+#[cfg(feature = "vship")]
 mod interp;
 mod noise;
 mod progs;
 mod scd;
 mod svt;
+#[cfg(feature = "vship")]
 mod tq;
+#[cfg(feature = "vship")]
 mod vship;
+#[cfg(feature = "vship")]
 mod zimg;
 
 const G: &str = "\x1b[1;92m";
@@ -28,7 +32,9 @@ const N: &str = "\x1b[0m";
 pub struct Args {
     pub worker: usize,
     pub scene_file: PathBuf,
+    #[cfg(feature = "vship")]
     pub target_quality: Option<String>,
+    #[cfg(feature = "vship")]
     pub qp_range: Option<String>,
     pub params: String,
     pub resume: bool,
@@ -60,10 +66,13 @@ fn print_help() {
     println!("-r|--resume    Resume the encoding. Example below");
     println!("-q|--quiet     Do not run any code related to any progress");
     println!();
-    println!("TQ:");
-    println!("-t|--tq        Allowed CVVDP Range for Target Quality. Example: `9.45-9.55`");
-    println!("-c|--qp        Allowed CRF/QP search range for Target Quality. Example: `12.25-44.75`");
-    println!();
+    #[cfg(feature = "vship")]
+    {
+        println!("TQ:");
+        println!("-t|--tq        Allowed CVVDP Range for Target Quality. Example: `9.45-9.55`");
+        println!("-c|--qp        Allowed CRF/QP search range for Target Quality. Example: `12.25-44.75`");
+        println!();
+    }
     println!("Misc:");
     println!("-n|--noise     Apply photon noise [1-64]: 1=ISO100, 64=ISO6400");
     println!();
@@ -108,6 +117,7 @@ fn apply_defaults(args: &mut Args) {
         args.scene_file = PathBuf::from(format!("scd_{stem}.txt"));
     }
 
+    #[cfg(feature = "vship")]
     if args.target_quality.is_some() && args.qp_range.is_none() {
         args.qp_range = Some("10.0-40.0".to_string());
     }
@@ -120,7 +130,9 @@ fn get_args(args: &[String]) -> Result<Args, Box<dyn std::error::Error>> {
 
     let mut worker = 0;
     let mut scene_file = PathBuf::new();
+    #[cfg(feature = "vship")]
     let mut target_quality = None;
+    #[cfg(feature = "vship")]
     let mut qp_range = None;
     let mut params = String::new();
     let mut resume = false;
@@ -144,12 +156,14 @@ fn get_args(args: &[String]) -> Result<Args, Box<dyn std::error::Error>> {
                     scene_file = PathBuf::from(&args[i]);
                 }
             }
+            #[cfg(feature = "vship")]
             "-t" | "--tq" => {
                 i += 1;
                 if i < args.len() {
                     target_quality = Some(args[i].clone());
                 }
             }
+            #[cfg(feature = "vship")]
             "-c" | "--qp" => {
                 i += 1;
                 if i < args.len() {
@@ -199,7 +213,9 @@ fn get_args(args: &[String]) -> Result<Args, Box<dyn std::error::Error>> {
     let mut result = Args {
         worker,
         scene_file,
+        #[cfg(feature = "vship")]
         target_quality,
+        #[cfg(feature = "vship")]
         qp_range,
         params,
         resume,

--- a/src/progs.rs
+++ b/src/progs.rs
@@ -323,6 +323,7 @@ impl ProgsTrack {
         std::io::stdout().flush().unwrap();
     }
 
+    #[cfg(feature = "vship")]
     pub fn show_metric(
         &self,
         chunk_idx: usize,


### PR DESCRIPTION
This enables a simpler build experience for users who don't require target quality, as it removes the vship dependency.