### PR TITLE
fix: use ffms2 for av-scenechange decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,15 @@ categories = ["multimedia::video", "command-line-utilities"]
 
 [features]
 default = []
-static = ["av-decoders"]
+static = []
 vship = []
 
 [dependencies]
 libc = "0.2.178"
 crossbeam-channel = "0.5.15"
-av-decoders = { version = "0.5.0", default-features = false, features = ["ffmpeg_static"], optional = true }
-av-scenechange = { git = "https://github.com/rust-av/av-scenechange", default-features = false, features = ["ffmpeg", "asm", "nasm-rs", "cc", "libc"] }
+av-scenechange = { version = "0.19.0", default-features = false, features = ["ffms2", "asm", "nasm-rs", "cc", "libc"] }
 av1-grain = "0.2.5"
+ffms2-sys = "0.2"
 
 [profile.release]
 opt-level = 3

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crossbeam_channel::Sender;
+use ffms2_sys::FFMS_VideoSource;
 
 use crate::chunk::Chunk;
 use crate::ffms::{
@@ -246,7 +247,7 @@ pub fn decode_chunks(
 #[inline]
 fn dec_10_fast(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     inf: &VidInf,
     w: u32,
     h: u32,
@@ -263,7 +264,7 @@ fn dec_10_fast(
 #[inline]
 fn dec_10_stride(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     inf: &VidInf,
     w: u32,
     h: u32,
@@ -280,7 +281,7 @@ fn dec_10_stride(
 #[inline]
 fn dec_10_crop_fast(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     cc: &CropCalc,
     w: u32,
     h: u32,
@@ -297,7 +298,7 @@ fn dec_10_crop_fast(
 #[inline]
 fn dec_10_crop(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     cc: &CropCalc,
     w: u32,
     h: u32,
@@ -314,7 +315,7 @@ fn dec_10_crop(
 #[inline]
 fn dec_10_crop_stride(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     cc: &CropCalc,
     w: u32,
     h: u32,
@@ -331,7 +332,7 @@ fn dec_10_crop_stride(
 #[inline]
 fn dec_8_fast(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     inf: &VidInf,
     w: u32,
     h: u32,
@@ -348,7 +349,7 @@ fn dec_8_fast(
 #[inline]
 fn dec_8_stride(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     inf: &VidInf,
     w: u32,
     h: u32,
@@ -365,7 +366,7 @@ fn dec_8_stride(
 #[inline]
 fn dec_8_crop_fast(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     cc: &CropCalc,
     w: u32,
     h: u32,
@@ -382,7 +383,7 @@ fn dec_8_crop_fast(
 #[inline]
 fn dec_8_crop(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     cc: &CropCalc,
     w: u32,
     h: u32,
@@ -399,7 +400,7 @@ fn dec_8_crop(
 #[inline]
 fn dec_8_crop_stride(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     inf: &VidInf,
     cc: &CropCalc,
     w: u32,
@@ -419,7 +420,7 @@ fn dec_8_crop_stride(
 #[inline]
 fn dec_10_fast_rem(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     inf: &VidInf,
     w: u32,
     h: u32,
@@ -436,7 +437,7 @@ fn dec_10_fast_rem(
 #[inline]
 fn dec_10_stride_rem(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     inf: &VidInf,
     w: u32,
     h: u32,
@@ -453,7 +454,7 @@ fn dec_10_stride_rem(
 #[inline]
 fn dec_10_crop_fast_rem(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     cc: &CropCalc,
     w: u32,
     h: u32,
@@ -470,7 +471,7 @@ fn dec_10_crop_fast_rem(
 #[inline]
 fn dec_10_crop_rem(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     cc: &CropCalc,
     w: u32,
     h: u32,
@@ -487,7 +488,7 @@ fn dec_10_crop_rem(
 #[inline]
 fn dec_10_crop_stride_rem(
     ch: &Chunk,
-    src: *mut std::ffi::c_void,
+    src: *mut FFMS_VideoSource,
     cc: &CropCalc,
     w: u32,
     h: u32,

--- a/src/svt.rs
+++ b/src/svt.rs
@@ -13,6 +13,7 @@ use crate::decode::decode_chunks;
 use crate::ffms::{VidIdx, VidInf};
 use crate::pipeline::Pipeline;
 use crate::progs::ProgsTrack;
+#[cfg(feature = "vship")]
 use crate::worker::Semaphore;
 #[cfg(feature = "vship")]
 use crate::worker::TQState;

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -48,6 +48,7 @@ pub struct Semaphore {
 }
 
 impl Semaphore {
+    #[cfg(feature = "vship")]
     pub const fn new(permits: usize) -> Self {
         Self { state: Mutex::new(permits), cvar: Condvar::new() }
     }
@@ -60,6 +61,7 @@ impl Semaphore {
         *count -= 1;
     }
 
+    #[cfg(feature = "vship")]
     pub fn release(&self) {
         *self.state.lock().unwrap() += 1;
         self.cvar.notify_one();


### PR DESCRIPTION
This should resolve some issues that were occurring with ffmpeg's API attempting to decode VP9 and AV1 source videos.