### PR TITLE
fix: consistently use stderr for progress

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,8 +65,8 @@ pub struct Args {
 }
 
 extern "C" fn restore() {
-    print!("\x1b[?25h\x1b[?1049l");
-    let _ = std::io::stdout().flush();
+    eprint!("\x1b[?25h\x1b[?1049l");
+    let _ = std::io::stderr().flush();
 }
 extern "C" fn exit_restore(_: i32) {
     restore();
@@ -433,12 +433,12 @@ const fn scale_crop(
 }
 
 fn main_with_args(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
-    print!("\x1b[?1049h\x1b[H\x1b[?25l");
-    std::io::stdout().flush().unwrap();
+    eprint!("\x1b[?1049h\x1b[H\x1b[?25l");
+    std::io::stderr().flush().unwrap();
 
     ensure_scene_file(args)?;
 
-    println!();
+    eprintln!();
 
     let hash = hash_input(&args.input);
     let work_dir = args.input.with_file_name(format!(".{}", &hash[..7]));
@@ -551,8 +551,8 @@ fn main_with_args(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
         fs::remove_file(&video_mkv)?;
     }
 
-    print!("\x1b[?25h\x1b[?1049l");
-    std::io::stdout().flush().unwrap();
+    eprint!("\x1b[?25h\x1b[?1049l");
+    std::io::stderr().flush().unwrap();
 
     let input_size = fs::metadata(&args.input)?.len();
     let output_size = fs::metadata(&args.output)?.len();
@@ -596,7 +596,7 @@ fn main_with_args(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
 {P}┗━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛{N}",
     args.input.file_name().unwrap().to_string_lossy(),
     args.output.file_name().unwrap().to_string_lossy(),
-    format!("{} {C}({:.0} kb/s) {G}󰛂 {G}{} {C}({:.0} kb/s) {}{} {:.2}%", 
+    format!("{} {C}({:.0} kb/s) {G}󰛂 {G}{} {C}({:.0} kb/s) {}{} {:.2}%",
         fmt_size(input_size), input_br, fmt_size(output_size), output_br, change_color, arrow, change.abs()),
     final_width, final_height, fps_rate, dh, dm, ds, "",
     eh, em, es, enc_speed, ""
@@ -612,8 +612,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let output = args.output.clone();
 
     std::panic::set_hook(Box::new(move |panic_info| {
-        print!("\x1b[?25h\x1b[?1049l");
-        let _ = std::io::stdout().flush();
+        eprint!("\x1b[?25h\x1b[?1049l");
+        let _ = std::io::stderr().flush();
         eprintln!("{panic_info}");
         eprintln!("{}, FAIL", output.display());
     }));
@@ -626,8 +626,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if let Err(e) = main_with_args(&args) {
-        print!("\x1b[?1049l");
-        std::io::stdout().flush().unwrap();
+        eprint!("\x1b[?1049l");
+        std::io::stderr().flush().unwrap();
         eprintln!("{}, FAIL", args.output.display());
         return Err(e);
     }

--- a/src/progs.rs
+++ b/src/progs.rs
@@ -62,12 +62,12 @@ impl ProgsBar {
         let perc = (current * 100 / total.max(1)).min(100);
         let (eta_h, eta_m, eta_s) = (eta_secs / 3600, (eta_secs % 3600) / 60, eta_secs % 60);
 
-        print!(
+        eprint!(
             "\r\x1b[2K{W}IDX: {C}[{bar}{C}] {W}{perc}%{C}, {Y}{mbps} MBs{C}, \
              {W}{eta_h:02}{P}:{W}{eta_m:02}{P}:{W}{eta_s:02}{C}, \
              {G}{mb_current}{C}/{R}{mb_total}{N}"
         );
-        std::io::stdout().flush().unwrap();
+        std::io::stderr().flush().unwrap();
     }
 
     pub fn up_scenes(&mut self, current: usize, total: usize) {
@@ -86,21 +86,21 @@ impl ProgsBar {
         let perc = (current * 100 / total.max(1)).min(100);
         let (eta_m, eta_s) = ((eta_secs % 3600) / 60, eta_secs % 60);
 
-        print!(
+        eprint!(
             "\r\x1b[2K{W}SCD: {C}[{bar}{C}] {W}{perc}%{C}, {Y}{fps} FPS{C}, \
              {W}{eta_m:02}{P}:{W}{eta_s:02}{C}, {G}{current}{C}/{R}{total}{N}"
         );
-        std::io::stdout().flush().unwrap();
+        std::io::stderr().flush().unwrap();
     }
 
     pub fn finish() {
-        print!("\r\x1b[2K");
-        std::io::stdout().flush().unwrap();
+        eprint!("\r\x1b[2K");
+        std::io::stderr().flush().unwrap();
     }
 
     pub fn finish_scenes() {
-        print!("\r\x1b[2K");
-        std::io::stdout().flush().unwrap();
+        eprint!("\r\x1b[2K");
+        std::io::stderr().flush().unwrap();
     }
 }
 
@@ -124,8 +124,8 @@ impl ProgsTrack {
     ) -> Self {
         let (tx, rx) = crossbeam_channel::unbounded();
 
-        print!("\x1b[s");
-        std::io::stdout().flush().unwrap();
+        eprint!("\x1b[s");
+        std::io::stderr().flush().unwrap();
 
         let total_chunks = chunks.len();
         let total_frames = chunks.iter().map(|c| c.end - c.start).sum();
@@ -208,8 +208,8 @@ fn watch_svt(
         let text = text.trim();
 
         if text.contains("error") || text.contains("Error") {
-            print!("\x1b[?1049l");
-            std::io::stdout().flush().unwrap();
+            eprint!("\x1b[?1049l");
+            std::io::stderr().flush().unwrap();
             eprintln!("{text}");
         }
 
@@ -345,8 +345,8 @@ fn watch_vvenc(
                     line_buf = line_buf[pos + 1..].to_string();
 
                     if line.contains("error") || line.contains("Error") {
-                        print!("\x1b[?1049l");
-                        std::io::stdout().flush().unwrap();
+                        eprint!("\x1b[?1049l");
+                        std::io::stderr().flush().unwrap();
                         eprintln!("{line}");
                     }
 
@@ -464,8 +464,8 @@ fn watch_x265(
             if text.starts_with("encoded") {
                 continue;
             }
-            print!("\x1b[?1049l");
-            std::io::stdout().flush().unwrap();
+            eprint!("\x1b[?1049l");
+            std::io::stderr().flush().unwrap();
             eprintln!("{text}");
             continue;
         }
@@ -565,17 +565,17 @@ fn draw_screen(
     processed: &Arc<AtomicUsize>,
     init_frames: usize,
 ) {
-    print!("\x1b[u");
+    eprint!("\x1b[u");
 
     for line in lines.iter().take(worker_count) {
         if line.is_empty() {
-            print!("\r\x1b[2K\n");
+            eprint!("\r\x1b[2K\n");
         } else {
-            print!("\r\x1b[2K{line}\n");
+            eprint!("\r\x1b[2K{line}\n");
         }
     }
 
-    print!("\r\x1b[2K\n");
+    eprint!("\r\x1b[2K\n");
 
     let data = state.completions.lock().unwrap();
     let completed_frames: usize = data.chnks_done.iter().map(|c| c.frames).sum();
@@ -614,7 +614,7 @@ fn draw_screen(
     let eta_h = (eta_secs / 3600).min(99);
     let eta_m = (eta_secs % 3600) / 60;
 
-    print!(
+    eprint!(
         "\r\x1b[2K{W}{h:02}{P}:{W}{m:02} {C}[{G}{chunks_done}{C}/{R}{}{C}] [{bar}{C}] {W}{perc}% \
          {G}{frames_done}{C}/{R}{} {C}({Y}{fps:.2}{C}, {W}{eta_h:02}{P}:{W}{eta_m:02}{C}, \
          {bitrate_str}{C}, {est_str}{C}{N})\n",


### PR DESCRIPTION
This resolves the race condition that was causing the summary report to sometimes be overwritten. The summary report was being written to stderr, but the other progress lines were being written to stdout, and the two outputs would sometimes resolve in the correct order but sometimes would not. This change consistently uses stderr, which is the recommendation for progress reporting.