### PR TITLE
build.sh: check pacman dependencies with pacman -T before installing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,10 @@ install_deps() {
                 "pacman")
                         pkgs=(base-devel rustup nasm clang compiler-rt cmake llvm lld ninja meson ffmpeg curl gcc)
                         ((${mode_choice:-0} == 1)) && pkgs+=(cuda)
-                        ${priv:-} pacman -S --needed --noconfirm "${pkgs[@]}"
+                        mapfile -t needed_pkgs < <(pacman -T "${pkgs[@]}" 2>/dev/null || true)
+                        if ((${#needed_pkgs[@]} > 0 && ${#needed_pkgs[0]} > 0)); then
+                                ${priv:-} pacman -S --needed --noconfirm "${needed_pkgs[@]}"
+                        fi
                         ;;
                 "dnf")
                         pkgs=(


### PR DESCRIPTION
`pacman -S --needed` only checks for package names and ignores provides, which made it ignore my clang-static-git AUR package